### PR TITLE
Add layout graphic to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,44 +2,8 @@
 
 ![Corne-ish Zen Logo](img/Zen_R3_sticker.png)
 
-**NOTE: This code is currently merged into ZMK Main.**
+You are viewing a fork of the [official configuration repo](https://github.com/LOWPROKB/zmk-config-Zen-2). The Corne-ish Zen uses ZMK firmware.
 
-This repo is the official configuration of the Corne-ish Zen V2 low profile wireless mechanical keyboard. Use it to develop your own keymap and easily build your own ZMK firmware to run on your Corne-ish Zen. These steps will get you using your keymap on your keyboard in the fastest time possible. It uses the GitHub Actions feature to build your firmware online, rather than setting up a complex tool chain on your local computer.
+This repo implements the keyboard layout below. It is my streamlined version of the [miryoku layout](https://github.com/manna-harbour/miryoku).
 
-If you are looking to dig deeper into ZMK and develop new functionality, it is recommended to follow the steps of installing ZMK as found on the official ZMK documentation site (linked below).
-
-V2 PCBs were only used in the 3rd GB round (R3). To confirm which version you need, remove the bottom from the keyboard and look beside the Corne-ish Zen logo for a version number. Group Buy rounds 1 and 2 have V1 PCBs and R3 has V2 PCBs. (Also V2 PCBs have white power switches... V1 PCBs have black ones.)
-
-## Resources
-
-- The [official ZMK Firmware GitHub](https://github.com/zmkfirmware/zmk) repository. View the keymaps for other boards and shields as a starting point for your keymap.
-- The [official ZMK Documentation](https://zmk.dev/docs) web site. Find the answers to many of your questions about ZMK Firmware.
-- The [official ZMK Discord Server](https://zmk.dev/community/discord/invite). Instant conversations with other ZMK developers and users. Great technical resource!
-
-## Instructions
-
-1. Log into, or sign up for, your personal GitHub account.
-2. Fork this repository to your local computer, and then push it to your GitHub personal account. ([instructions](https://docs.github.com/en/get-started/quickstart/fork-a-repo))
-3. Edit the keymap file(s) to suit your needs:
-    - Change [the keymap file](/config/corneish_zen.keymap) to edit keycodes, add new layers etc.
-    - Change [the conf file](/config/corneish_zen.conf) to edit configuration settings like changing the deep sleep timeout
-4. Commit and push your changes to your personal repo. Upon pushing it, GitHub Actions will start building a new version of your firmware with the updated keymap.
-
-> **Note**
-> 
-> After forking the repo to your own account, you can also edit the files directly using the GitHub web interface via the edit button on the top right (keyboard shortcut `e`) or via the [GitHub Dev](https://github.com/github/dev) interface (keyboard shortcut `.`) and commit your changes.
-
-## Firmware Files
-
-To locate your firmware files...
-
-1. Log into GitHub and navigate to your personal config repository you just uploaded your keymap changes to.
-2. Click "Actions" in the main navigation, and in the left navigation click the "Build" link.
-3. Select the desired workflow run in the centre area of the page (based on date and time of the build you wish to use). You can also start a new build from this page by clicking the "Run workflow" button.
-4. After clicking the desired workflow run, you should be presented with a section at the bottom of the page called "Artifacts". This section contains the results of your build, in a file called "firmware.zip"
-5. Download the firmware zip archive and extract the two `.uf2` files. They are named according to which side they need to be flashed to.
-6. Flash the firmware to your keyboard by double-clicking the reset button to put the it in bootloader mode. A window should pop up showing the contents of the storage on the keyboard. Drag and drop the correct `.uf2` file into the window. When the upload is complete the window will close and the keyboard will exit bootloader mode.
-    - If you only changed [the keymap file](/config/corneish_zen.keymap) you only need to flash the left side firmware to the left side.
-    - If you changed [the conf file](/config/corneish_zen.conf) you should flash both sides their respective files.
-
-Your keyboard is now ready to use.
+![keyboard layout](img/miryoku-simplified.png)


### PR DESCRIPTION
Rewrote README to be simpler: link to upstream, graphic of the implemented layout, make ZMK firmware dependency explicit